### PR TITLE
Set forms.op as optional

### DIFF
--- a/thingDescription/FormElementAction.go
+++ b/thingDescription/FormElementAction.go
@@ -1,7 +1,7 @@
 package thingDescription
 
 type FormElementAction struct {
-	Op                  *FormElementActionOp            `json:"op"`
+	Op                  *FormElementActionOp            `json:"op,omitempty"`
 	AdditionalResponses []AdditionalResponsesDefinition `json:"additionalResponses,omitempty"`
 	ContentCoding       *string                         `json:"contentCoding,omitempty"`
 	ContentType         *string                         `json:"contentType,omitempty"`

--- a/thingDescription/FormElementEvent.go
+++ b/thingDescription/FormElementEvent.go
@@ -1,7 +1,7 @@
 package thingDescription
 
 type FormElementEvent struct {
-	Op                  *FormElementEventOp             `json:"op"`
+	Op                  *FormElementEventOp             `json:"op,omitempty"`
 	AdditionalResponses []AdditionalResponsesDefinition `json:"additionalResponses,omitempty"`
 	ContentCoding       *string                         `json:"contentCoding,omitempty"`
 	ContentType         *string                         `json:"contentType,omitempty"`

--- a/thingDescription/FormElementProperty.go
+++ b/thingDescription/FormElementProperty.go
@@ -7,7 +7,7 @@ import (
 )
 
 type FormElementProperty struct {
-	Op                  *FormElementPropertyOp          `json:"op"`
+	Op                  *FormElementPropertyOp          `json:"op,omitempty"`
 	AdditionalResponses []AdditionalResponsesDefinition `json:"additionalResponses,omitempty"`
 	ContentCoding       *string                         `json:"contentCoding,omitempty"`
 	ContentType         *string                         `json:"contentType,omitempty"`


### PR DESCRIPTION
The forms.op field should be optional. If not set, the default values defined in the WoT specification will be used. https://www.w3.org/TR/wot-thing-description11/#table-default-values-of-vocabulary-terms-that-are-used-when-the-terms-are-not-present-in-a-td